### PR TITLE
add: inject ip address and node name into tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This JSON file specifies the groups of nodes and associated partitions that Slur
       * `LaunchTemplateSpecification`: Must be filled in the same way than the object of the same name in the [EC2 CreateFleet API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_fleet).
       * `LaunchTemplateOverrides`: Must be filled in the same way then the object of the same name in the [EC2 CreateFleet API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_fleet). Do not populate the field `SubnetId` in template overrides.
       * `SubnetIds`: List of subnets where EC2 instances can be launched for this node group. If you provide multiple subnets, they must be in different availability zones.
-      * `Tags`: List of tags applied to the EC2 instances launched for this node group.
+      * `Tags`: List of tags applied to the EC2 instances launched for this node group. The sequence "%n" will be replaced with the node name and "%i" will be replaced with the ip address.
 
 Refer to the section **Examples of `partitions.json`** for examples of file content.
 

--- a/resume.py
+++ b/resume.py
@@ -133,7 +133,8 @@ for partition_name, nodegroups in nodes_to_resume.items():
                     }
                 ]
                 if 'Tags' in nodegroup:
-                    tags += nodegroup['Tags']
+                    # Replace any instance of %n with node name in tags
+                    tags += [ {k: t[k].replace('%n', node_name).replace('%i', ip_address) for k in t} for t in nodegroup['Tags'] ]
                 try:
                     request_tags = {
                         'Resources': [instance_id],


### PR DESCRIPTION
Needed ability to inject node name and ip address into tags of the instance.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
