### PR TITLE
Improved GPU support, including gres.conf auto-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Single `aws` partition with 2 node groups:
             }
          ],
       "PartitionOptions": {
+         "Default": "yes",
          "TRESBillingWeights": "cpu=4"
          }
       }

--- a/template.yaml
+++ b/template.yaml
@@ -329,6 +329,9 @@ Resources:
                              ]
                           }
                        ]
+                    },
+                    "PartitionOptions": {
+                       "Default": "Yes"
                     }
                  ]
               }

--- a/template.yaml
+++ b/template.yaml
@@ -368,12 +368,14 @@ Resources:
               SlurmdLogFile=/var/log/slurmd.log
               DebugFlags=NO_CONF_HASH
               JobCompType=jobcomp/none
+              GresTypes=gpu
               EOF
               sed -i "s|@HEADNODE@|$HOSTNAME|g" $SLURM_HOME/etc/slurm.conf
 
               # Configure the plugin
               $SLURM_HOME/etc/aws/generate_conf.py
               cat $SLURM_HOME/etc/aws/slurm.conf.aws >> $SLURM_HOME/etc/slurm.conf
+              cp $SLURM_HOME/etc/aws/gres.conf.aws $SLURM_HOME/etc/gres.conf
 
               crontab -l > mycron
               cat > mycron <<EOF


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*  I modified generate_conf.py to create a gres.conf based on Gres entries in the SlurmSpecification in partitions.json, and modified the template to add GresTypes=gpu in slurm.conf and a line to copy gres.conf.aws to gres.conf in the cloud-init script.

Also, I added Default=yes to the PartitionOptions in template.yaml and in one of the partitions.json examples in the readme.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
