### PR TITLE
Fixes for the quickstart template.yaml to enable working deployment of the plugin

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -122,14 +122,6 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-      Policies:
-        - PolicyName: DescribeTagsPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action: ec2:DescribeTags
-                Resource: "*"
 
   ComputeNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -155,7 +147,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - ec2:CreateFleet
-                  - ec2:DescribeTags
                   - ec2:RunInstances
                   - ec2:TerminateInstances
                   - ec2:CreateTags
@@ -423,32 +414,17 @@ Resources:
                   exit 1
               fi
 
-              # Get instance ID using IMDSv2
-              INSTANCE_ID=$(get_metadata "instance-id" "$TOKEN")
-
-              # Get availability zone and extract region from it
-              AZ=$(get_metadata "placement/availability-zone" "$TOKEN")
-              REGION=$(echo "$AZ" | sed 's/[a-z]$//')
-
-              if [ -z "$INSTANCE_ID" ] || [ -z "$REGION" ]; then
-                  echo "Error: Failed to retrieve instance ID or region"
-                  exit 1
-              fi
-
-              # Get the Name tag value using AWS CLI with dynamic region
-              NAME_TAG=$(aws ec2 describe-tags \
-                  --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=Name" \
-                  --query "Tags[0].Value" \
-                  --output text \
-                  --region "$REGION")
+              # Get the Name tag directly from instance metadata
+              NAME_TAG=$(get_metadata "tags/instance/Name" "$TOKEN")
 
               # Check if the Name tag exists
-              if [ "$NAME_TAG" = "None" ] || [ -z "$NAME_TAG" ]; then
-                  echo "No Name tag found for instance $INSTANCE_ID"
+              if [ -z "$NAME_TAG" ]; then
+                  echo "No Name tag found for instance"
                   exit 1
               else
                   echo "$NAME_TAG"
               fi
+
               EOF
               chmod +x $SLURM_HOME/etc/aws/get_nodename
 

--- a/template.yaml
+++ b/template.yaml
@@ -188,7 +188,7 @@ Resources:
           Fn::Base64:
             !Sub |
               #!/bin/bash -x
-              yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+              amazon-linux-extras install epel -y
               yum install munge munge-libs munge-devel -y
 
               echo "welcometoslurmamazonuserwelcometoslurmamazonuserwelcometoslurmamazonuser" | tee /etc/munge/munge.key
@@ -231,7 +231,7 @@ Resources:
               # Install packages
               yum update -y
               yum install nfs-utils python2 python2-pip python3 python3-pip -y
-              yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+              amazon-linux-extras install epel -y
               yum install munge munge-libs munge-devel openssl openssl-devel pam-devel numactl numactl-devel hwloc hwloc-devel lua lua-devel readline-devel rrdtool-devel ncurses-devel man2html libibmad libibumad rpm-build libyaml http-parser-devel json-c-devel perl-devel -y
               yum groupinstall "Development Tools" -y
               pip3 install boto3

--- a/template.yaml
+++ b/template.yaml
@@ -397,14 +397,57 @@ Resources:
 
               # Get dynamically the node name when launching slurmd
               cat > $SLURM_HOME/etc/aws/get_nodename <<'EOF'
-              instanceid=`/usr/bin/curl --fail -m 2 -s http://169.254.169.254/latest/meta-data/instance-id`
-              if [[ ! -z "$instanceid" ]]; then
-                 hostname=`/usr/bin/curl -s http://169.254.169.254/latest/meta-data/tags/instance/Name`
+              #!/bin/bash
+
+              # Function to get IMDSv2 token
+              get_imds_token() {
+                  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+                      -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+                      -s)
+                  echo "$TOKEN"
+              }
+
+              # Function to get metadata using IMDSv2
+              get_metadata() {
+                  local path=$1
+                  local token=$2
+                  curl -H "X-aws-ec2-metadata-token: $token" \
+                      -s "http://169.254.169.254/latest/meta-data/${!path}"
+              }
+
+              # Get IMDSv2 token
+              TOKEN=$(get_imds_token)
+
+              if [ -z "$TOKEN" ]; then
+                  echo "Error: Failed to retrieve IMDSv2 token. Are you running this on an EC2 instance?"
+                  exit 1
               fi
-              if [ ! -z "$hostname" -a "$hostname" != "None" ]; then
-                 echo $hostname
+
+              # Get instance ID using IMDSv2
+              INSTANCE_ID=$(get_metadata "instance-id" "$TOKEN")
+
+              # Get availability zone and extract region from it
+              AZ=$(get_metadata "placement/availability-zone" "$TOKEN")
+              REGION=$(echo "$AZ" | sed 's/[a-z]$//')
+
+              if [ -z "$INSTANCE_ID" ] || [ -z "$REGION" ]; then
+                  echo "Error: Failed to retrieve instance ID or region"
+                  exit 1
+              fi
+
+              # Get the Name tag value using AWS CLI with dynamic region
+              NAME_TAG=$(aws ec2 describe-tags \
+                  --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=Name" \
+                  --query "Tags[0].Value" \
+                  --output text \
+                  --region "$REGION")
+
+              # Check if the Name tag exists
+              if [ "$NAME_TAG" = "None" ] || [ -z "$NAME_TAG" ]; then
+                  echo "No Name tag found for instance $INSTANCE_ID"
+                  exit 1
               else
-                 echo `hostname`
+                  echo "$NAME_TAG"
               fi
               EOF
               chmod +x $SLURM_HOME/etc/aws/get_nodename

--- a/template.yaml
+++ b/template.yaml
@@ -122,6 +122,14 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: DescribeTagsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ec2:DescribeTags
+                Resource: "*"
 
   ComputeNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -147,6 +155,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ec2:CreateFleet
+                  - ec2:DescribeTags
                   - ec2:RunInstances
                   - ec2:TerminateInstances
                   - ec2:CreateTags


### PR DESCRIPTION
*Issue #, if available:* 

Slurm environment deployed using the `template.yaml` file does not work. `slurmd` service failed to start in the compute nodes. Munge package failed to install.

*Description of changes:* 

Updated `template.yaml` to change the EC2 user-data.  The change are: 1. command for installing the EPEL release package 2 in Amazon Linux2. 2. Use the right compute node name as defined in the `slurm.conf` while bursting using `IMDSv2` from `IMDSv1`. This PR should also address the https://github.com/aws-samples/aws-plugin-for-slurm/issues/26


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
